### PR TITLE
Escape missing index in BAM file

### DIFF
--- a/bam_sample.py
+++ b/bam_sample.py
@@ -225,6 +225,10 @@ def main(argv=None):
         parser.error('Sample has to be specified when outputting to VCF')
 
     bam = pysam.AlignmentFile(args.bam)
+    if not bam.has_index():
+        print("BAM file does not seem to index. An index is required for sampling.",
+              file=sys.stderr)
+        sys.exit(1)
     ref = pysam.FastaFile(args.ref)
 
     # output the results as specified by user


### PR DESCRIPTION
Checks if the provided BAM file has an index, which is required for
pileup, and terminates the script straight away, if not.